### PR TITLE
Add Flow Translate cask

### DIFF
--- a/Casks/flow-translate.rb
+++ b/Casks/flow-translate.rb
@@ -1,0 +1,24 @@
+cask "flow-translate" do
+  version "1.0.0"
+  sha256 "1ab29a9b264345c6b99ea4eae8bb6b415999c494b6383b813d135ed8f8f0fbe1"
+
+  url "https://github.com/huang422/EdgeAI-Flow-Translate/releases/download/v#{version}/FlowTranslate.dmg"
+  name "Flow Translate"
+  desc "Local real-time bilingual captions, transcripts, and meeting summaries"
+  homepage "https://github.com/huang422/EdgeAI-Flow-Translate"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :arm64
+  depends_on macos: :sequoia
+
+  app "FlowTranslate.app"
+
+  zap trash: [
+    "~/Library/Application Support/FlowTranslate",
+    "~/Library/Preferences/dev.flowtranslate.app.plist",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ This is a Homebrew tap for interetsing tools that are not in the main Homebrew r
     ```bash
     brew install eoleedi/tap/timetree-exporter
     ```
+
+3. Install [Flow Translate](https://github.com/huang422/EdgeAI-Flow-Translate)
+
+    ```bash
+    brew install --cask eoleedi/tap/flow-translate
+    ```


### PR DESCRIPTION
## Summary
- add Flow Translate 1.0.0 cask
- document cask install command in README

## Validation
- brew style Casks/flow-translate.rb

Note: brew audit by path is disabled in current Homebrew, and the local cask token is not resolvable before the tap branch is published.