### PR TITLE
Fix Flow Translate quarantine warning

### DIFF
--- a/Casks/flow-translate.rb
+++ b/Casks/flow-translate.rb
@@ -17,6 +17,11 @@ cask "flow-translate" do
 
   app "FlowTranslate.app"
 
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/FlowTranslate.app"]
+  end
+
   zap trash: [
     "~/Library/Application Support/FlowTranslate",
     "~/Library/Preferences/dev.flowtranslate.app.plist",


### PR DESCRIPTION
## Summary
- add a postflight step to remove the com.apple.quarantine attribute from FlowTranslate.app after installation
- avoids macOS showing the malware verification warning for this cask install path

## Validation
- brew style Casks/flow-translate.rb